### PR TITLE
Add cutout support

### DIFF
--- a/src/android/StatusBarViewHelper.java
+++ b/src/android/StatusBarViewHelper.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
+import android.view.DisplayCutout;					  
 
 /*
     Issue ID: CB-13300
@@ -76,9 +77,28 @@ public class StatusBarViewHelper {
         int uiOptions = activity.getWindow().getDecorView().getSystemUiVisibility();
         boolean isFullscreen = ((uiOptions | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN) == uiOptions);
 
-        //If not fullscreen, then we have to take the status bar into consideration (represented by r.top)
-        //r.bottom defines the keyboard, or navigation bar, or both.
-
-        return isFullscreen ? r.bottom : r.bottom - r.top;
+		int cutoutTop = 0; 
+		int cutoutBottom = 0; 
+		
+		// On devices with screen cutouts, this code will think that screen is available, when in reality it is not.
+		// This piece gets the cutout information so that we can correct the computeUsableHeight
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P)  {
+			DisplayCutout cutout = activity.getWindow().getDecorView().getRootWindowInsets().getDisplayCutout(); 
+			if (cutout !=null) { 
+				cutoutTop = cutout.getSafeInsetTop(); 
+				cutoutBottom = cutout.getSafeInsetBottom(); 
+			} 
+		}		
+		
+		int usableHeight = r.bottom - cutoutTop - cutoutBottom; 
+		
+		//If not fullscreen, then we have to take the status bar into consideration (represented by r.top)
+		//r.bottom defines the keyboard, or navigation bar, or both.
+		if (isFullscreen) 
+		{ 
+			usableHeight = usableHeight - r.top; 
+		} 
+		
+		return usableHeight;
     }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Adds support for devices with cutouts or "notches".

### Description
<!-- Describe your changes in detail -->

Uses getDisplayCutout() to reserve top/bottom space for it.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested on Samsung Galaxy S10 (with cutout), S8 (same resolution, no cutout), J3 (entry-level phone, older Android SDK), and Tab S (old tablet, just in case).

